### PR TITLE
fix: remove duplication of stack trace in errors

### DIFF
--- a/src/lib/github.js
+++ b/src/lib/github.js
@@ -95,7 +95,7 @@ module.exports = function (pkg, info, cb) {
 
     createAuthorization(info, (err, data) => {
       if (err) {
-        log.error('Could not login to GitHub. Check your credentials.', err)
+        log.error('Could not login to GitHub. Check your credentials.')
         return cb(err)
       }
 

--- a/src/lib/npm.js
+++ b/src/lib/npm.js
@@ -11,7 +11,7 @@ function getNpmToken (pkg, info, cb) {
     auth: info.npm
   }, (err, data) => {
     if (err) {
-      log.error('Could not login to npm registry. Check your credentials.', err)
+      log.error('Could not login to npm registry. Check your credentials.')
       return cb(err)
     }
 
@@ -26,7 +26,7 @@ module.exports = function (pkg, info, cb) {
 
   npmconf.load((err, conf) => {
     if (err) {
-      log.error('Could not load npm config.', err)
+      log.error('Could not load npm config.')
       return cb(err)
     }
 

--- a/src/lib/repository.js
+++ b/src/lib/repository.js
@@ -32,7 +32,7 @@ module.exports = function (pkg, info, cb) {
 
   getRemoteUrl(pkg, (err, rurl) => {
     if (err) {
-      log.error('Could not get repository url. Please create/add the repository.', err)
+      log.error('Could not get repository url. Please create/add the repository.')
       return cb(err)
     }
 

--- a/src/lib/travis.js
+++ b/src/lib/travis.js
@@ -65,7 +65,7 @@ function setEnvVar (info, name, value, cb) {
     `/settings/env_vars?repository_id=${info.travis.repoid}`,
     (err, res) => {
       if (err) {
-        log.error('Could not get environment variables on Travis CI.', err)
+        log.error('Could not get environment variables on Travis CI.')
         return cb(err)
       }
 
@@ -82,7 +82,7 @@ function setEnvVar (info, name, value, cb) {
           }
         }, (err, res) => {
           if (err) {
-            log.error('Could not set environment variable on Travis CI.', err)
+            log.error('Could not set environment variable on Travis CI.')
             return cb(err)
           }
 
@@ -123,7 +123,7 @@ function setUpTravis (pkg, info, cb) {
     .repos(info.ghrepo.slug[0], info.ghrepo.slug[1])
     .get((err, res) => {
       if (err) {
-        log.error('Could not get repository on Travis CI.', err)
+        log.error('Could not get repository on Travis CI.')
         return cb(err)
       }
 
@@ -175,7 +175,7 @@ module.exports = function (endpoint, pkg, info, cb) {
       github_token: info.github.token
     }, (err) => {
       if (err) {
-        log.error('Could not login to Travis CI.', err)
+        log.error('Could not login to Travis CI.')
         return cb(err)
       }
 


### PR DESCRIPTION
Error object is already logged by parent. Therefore, remove the duplication and
make the descriptive error message more prominent.

Closes #2.