### PR TITLE
Support git:// repository urls

### DIFF
--- a/src/lib/repository.js
+++ b/src/lib/repository.js
@@ -23,7 +23,7 @@ function getRemoteUrl (pkg, callback) {
   }
   if (/^git\+/.test(pkg.repository.url)) {
     pkg.repository.url = pkg.repository.url.substr(4)
-    pkg.repository.url = pkg.repository.url.replace(/^ssh:\/\/git@/, 'https://')
+    pkg.repository.url = pkg.repository.url.replace(/^(ssh:\/\/git|git:\/\/)@/, 'https://')
   }
   callback(null, pkg.repository.url)
 }


### PR DESCRIPTION
Without this, git:// urls fail with "Could not find repository on GitHub", which is misleading.