### PR TITLE
fix: parse repository url and always set protocol

### DIFF
--- a/src/lib/repository.js
+++ b/src/lib/repository.js
@@ -21,10 +21,12 @@ function getRemoteUrl (pkg, callback) {
     if (!repo) return callback(new Error('No repository found.'))
     pkg.repository = { type: 'git', url: `${ghUrl(repo)}.git` }
   }
-  if (/^git\+/.test(pkg.repository.url)) {
-    pkg.repository.url = pkg.repository.url.substr(4)
-    pkg.repository.url = pkg.repository.url.replace(/^ssh:\/\/git@/, 'https://')
-  }
+
+  let parsed = url.parse(pkg.repository.url);
+  parsed.auth = null;
+  parsed.protocol = 'https';
+  pkg.repository.url = url.format(parsed);
+
   callback(null, pkg.repository.url)
 }
 

--- a/src/lib/repository.js
+++ b/src/lib/repository.js
@@ -22,10 +22,10 @@ function getRemoteUrl (pkg, callback) {
     pkg.repository = { type: 'git', url: `${ghUrl(repo)}.git` }
   }
 
-  let parsed = url.parse(pkg.repository.url);
-  parsed.auth = null;
-  parsed.protocol = 'https';
-  pkg.repository.url = url.format(parsed);
+  let parsed = url.parse(pkg.repository.url)
+  parsed.auth = null
+  parsed.protocol = 'https'
+  pkg.repository.url = url.format(parsed)
 
   callback(null, pkg.repository.url)
 }


### PR DESCRIPTION
more robust than using regexes, supports git:// urls

(#21 redux)