### PR TITLE
update keytar to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "ini": "^1.3.4",
     "inquirer": "^0.9.0",
     "js-yaml": "^3.3.1",
-    "keytar": "^2.1.0",
+    "keytar": "^3.0.0",
     "lodash": "^3.9.3",
     "nopt": "^3.0.2",
     "npm-registry-client": "^6.4.0",


### PR DESCRIPTION
I recently updated to Node4 (Mac OSX) and the semantic-release-cli would error on install due to an outdated keytar dependency. keytar was recently updated to version `3.0.0` and once I updated keytar in the cli package.json, semantic-release-cli installed flawlessly.