### PR TITLE
fix(travis): use latest stable Node by default

### DIFF
--- a/src/lib/travis.js
+++ b/src/lib/travis.js
@@ -17,7 +17,7 @@ const travisyml = {
   notifications: {
     email: false
   },
-  node_js: ['iojs'],
+  node_js: ['node'],
   before_install: ['npm i -g npm@^2.0.0'],
   before_script: ['npm prune'],
   after_success: ['npm run semantic-release']
@@ -25,6 +25,7 @@ const travisyml = {
 
 const travisyml_multi = _.assign({}, travisyml, {
   node_js: [
+    '4.0',
     'iojs-v3',
     'iojs-v2',
     'iojs-v1',


### PR DESCRIPTION
Default to latest stable build of Node (v4.x). Added 4.0 to the multi versions list; presumably each major release should be added? Perhaps iojs should be removed now?