### PR TITLE
feat: add token command line options

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,9 @@ const knownOptions = {
   version: Boolean,
   help: Boolean,
   keychain: Boolean,
-  'ask-for-passwords': Boolean
+  'ask-for-passwords': Boolean,
+  'gh-token': String,
+  'npm-token': String
 }
 
 const shortHands = {
@@ -55,11 +57,13 @@ Usage:
   semantic-release-cli setup [--tag=<String>]
 
 Options:
-  -h --help           Show this screen.
-  -v --version        Show version.
-  --[no-]keychain     Use keychain to get passwords [default: true].
-  --ask-for-passwords Ask for the passwords even if passwords are stored [default: false].
-  --tag=<String>      npm tag to install [default: 'latest'].`)
+  -h --help            Show this screen.
+  -v --version         Show version.
+  --[no-]keychain      Use keychain to get passwords [default: true].
+  --ask-for-passwords  Ask for the passwords even if passwords are stored [default: false].
+  --tag=<String>       npm tag to install [default: 'latest'].
+  --gh-token=<String>  Github auth token
+  --npm-token=<String> NPM auth token`)
     process.exit(0)
   }
 

--- a/src/lib/npm.js
+++ b/src/lib/npm.js
@@ -49,27 +49,40 @@ module.exports = function (pkg, info, cb) {
       name: 'username',
       message: 'What is your npm username?',
       default: conf.get('username'),
-      validate: _.ary(_.bind(validator.isLength, null, _, 1), 1)
+      validate: _.ary(_.bind(validator.isLength, null, _, 1), 1),
+      when: function (answers) {
+        return !_.has(info.options, 'npm-token')
+      }
     }, {
       type: 'input',
       name: 'email',
       message: 'What is your npm email?',
       default: conf.get('email'),
-      validate: validator.isEmail
+      validate: validator.isEmail,
+      when: function (answers) {
+        return !_.has(info.options, 'npm-token')
+      }
     }, {
       type: 'password',
       name: 'password',
       message: 'What is your npm password?',
       validate: _.ary(_.bind(validator.isLength, null, _, 1), 1),
       when: function (answers) {
+        if (_.has(info.options, 'npm-token')) return false
         if (!info.options.keychain) return true
         if (info.options['ask-for-passwords']) return true
         return !passwordStorage.get(answers.username)
       }
     }], (answers) => {
-      answers.password = answers.password || passwordStorage.get(answers.username)
       info.npm = answers
 
+      if (_.has(info.options, 'npm-token')) {
+        info.npm.token = info.options['npm-token']
+        log.info('Using NPM token from command line argument.')
+        return cb(null)
+      }
+
+      answers.password = answers.password || passwordStorage.get(answers.username)
       conf.set('username', answers.username, 'user')
       conf.set('email', answers.email, 'user')
 


### PR DESCRIPTION
Add two command line options for authentication tokens:
`--gh-token`: Github personal access token
`--npm-token`: NPM access token

Closes #30