### PR TITLE
feat(setup): add retain-version option during setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ semantic-release-cli setup
 	  -v --version        Show version.
 	  --[no-]keychain     Use keychain to get passwords [default: true].
 	  --ask-for-passwords Ask for the passwords even if passwords are stored [default: false].
+    --retain-version     Retain version field in package.json [default: false].
 	  --tag=<String>      npm tag to install [default: 'latest'].
 
 ## What it Does

--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,7 @@ const knownOptions = {
   help: Boolean,
   keychain: Boolean,
   'ask-for-passwords': Boolean,
+  'retain-version': Boolean,
   'gh-token': String,
   'npm-token': String
 }
@@ -61,6 +62,7 @@ Options:
   -v --version         Show version.
   --[no-]keychain      Use keychain to get passwords [default: true].
   --ask-for-passwords  Ask for the passwords even if passwords are stored [default: false].
+  --retain-version     Retain version field in package.json [default: false].
   --tag=<String>       npm tag to install [default: 'latest'].
   --gh-token=<String>  Github auth token
   --npm-token=<String> NPM auth token`)
@@ -87,7 +89,9 @@ Options:
         process.exit(1)
       }
 
-      delete pkg.version
+      if (!info.options['retain-version']) {
+        delete pkg.version
+      }
 
       pkg.scripts = pkg.scripts || {}
       pkg.scripts['semantic-release'] = 'semantic-release pre && npm publish && semantic-release post'


### PR DESCRIPTION
It is neccesary at times not to remove the version field from package.json.
This change fixes this by adding the --retain-version flag so that people
may to decide the default behavior of removing the field.

Closes #71
