### PR TITLE
feat(travis): Default to supported CURRENT and LTS Node.js versions.

### DIFF
--- a/src/lib/travis.js
+++ b/src/lib/travis.js
@@ -17,7 +17,7 @@ const travisyml = {
   notifications: {
     email: false
   },
-  node_js: ['7', '6', '4'],
+  node_js: ['8', '6'],
   before_script: ['npm prune'],
   after_success: ['npm run semantic-release'],
   branches: {


### PR DESCRIPTION
The future is now! Node.js v4 is in maintenance mode, new packages probably shouldn't target it for
support. v7 is no longer supported and v8 is CURRENT.