### PR TITLE
fix(travis.yml): remove prune from `before_script`

### DIFF
--- a/src/lib/travis.js
+++ b/src/lib/travis.js
@@ -24,7 +24,6 @@ const travisyml = {
     '6',
     '4',
   ],
-  before_script: ['npm prune'],
   after_success: ['npm run semantic-release'],
   branches: {
     // ignore git tags created by semantic-release, like "v1.2.3"


### PR DESCRIPTION
we don't need that any longer as we don’t cache `node_modules`. Will also help with https://github.com/semantic-release/semantic-release/issues/351