### PR TITLE
fix(travis): prevent double builds on PRs

### DIFF
--- a/src/lib/travis.js
+++ b/src/lib/travis.js
@@ -24,8 +24,8 @@ const travisyml = {
   node_js: ['9', '8', '6', '4'], // eslint-disable-line camelcase
   after_success: ['npm run travis-deploy-once "npm run semantic-release"'], // eslint-disable-line camelcase
   branches: {
-    // ignore git tags created by semantic-release, like "v1.2.3"
-    except: [/^v\d+\.\d+\.\d+$/.toString()],
+    // Avoid double build on PRs (see: https://github.com/travis-ci/travis-ci/issues/1147)
+    only: ['master'],
   },
 };
 


### PR DESCRIPTION
Without this, if a PR is opened for a branch, Travis creates two builds;
one for the branch and one for the PR itself. When Travis is configured
(in the UI) to build both the push and PR (the default), I think a
better default for builds is to trigger only _one_ build.

Semantic release itself uses this set up, see:
https://github.com/semantic-release/commit-analyzer/issues/11