### PR TITLE
docs(travis): update documentation for case-sensitive repo name requirement of Travis CI API

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ For Travis CI, `semantic-release-cli` performs the following additional steps:
 1. Overwrite your `.travis.yml` file
 	* `after_success`: `npm install -g travis-deploy-once` and `travis-deploy-once "npm run semantic-release"`: run `semantic-release` exactly once after all builds pass
 	* Set other sane defaults: `cache: directories: ~/.npm`, `notifications: email: false`
-1. Login to Travis CI to configure the package
+1. Login to Travis CI to configure the package. This step requires your module to define a valid, case-sensitive
+[`repository` field](https://docs.npmjs.com/files/package.json#repository).
 	* Enable builds of your repo
 	* Add `GH_TOKEN` and `NPM_TOKEN` environment variables in the settings
 


### PR DESCRIPTION
Since the Travis CI APIs are case-sensitive (details: https://github.com/travis-ci/travis-ci/issues/1545),
the repo ID lookup will fail if the package.json repo URL does not match the case of the
Github repo name. For example, a package.json URL with "https://github.com/myorg/myproject"
will cause the Travis API repo ID lookup to fail if the Github repository is actually
"https://github.com/MyOrg/MyProject".

Relates to: #196