### PR TITLE
fix: throw exception if Github repository URL is invalid

### DIFF
--- a/src/lib/repository.js
+++ b/src/lib/repository.js
@@ -63,7 +63,8 @@ module.exports = async function(pkg, info) {
       },
     ]);
     info.ghepurl = answers.url;
-    return;
+    if (answers.enterprise) return;
+    throw new Error(`GitHub repository URL is invalid: ${repoUrl}`);
   }
 
   info.ghrepo = {slug: parsedUrl};


### PR DESCRIPTION
If the Github URL could not be parsed and an Enterprise Github URL is not provided,
exit CLI with an error instead of assigning a null value to info.ghrepo.slug.

Fixes #100