### PR TITLE
Fix npm otp login

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "lodash": "^4.16.4",
     "nopt": "^4.0.0",
     "npm": "^6.0.0",
-    "npm-registry-client": "^8.5.0",
+    "npm-profile": "^4.0.1",
     "npmlog": "^4.0.0",
     "p-retry": "^2.0.0",
     "parse-git-config": "^2.0.0",


### PR DESCRIPTION
This PR fixes https://github.com/semantic-release/cli/issues/213 by using the `npm-profile` library instead of `npm-registry-client`. It is much easier to use and has better login support.