### PR TITLE
fix: succeed on circleci with projects that circle already follows

### DIFF
--- a/src/lib/circle.js
+++ b/src/lib/circle.js
@@ -107,8 +107,7 @@ async function followProject(info, defaultReq) {
       info.log.info(`Succesfully followed repo ${info.ghrepo.slug[0]}/${info.ghrepo.slug[1]} on CircleCI.`);
     })
     .catch(() => {
-      info.log.error('Error following repo on CircleCI!');
-      process.exit(1); // eslint-disable-line unicorn/no-process-exit
+      info.log.warn('Error following repo on CircleCI! It might mean you are already following it, so I will try to continue.');
     });
 }
 


### PR DESCRIPTION
Had the same problem as #215  - this is a fix for an edge case. 

Circleci responds with 500 when you try to follow a project you already follow. We could try to fetch all the projects followed by circle and then see if the one we are working with is on the list - but that's extra calls (time) and complexity in the package, while from my perspective not really adding any extra debugging value to the user. Especially comparing to the current situation. 

