### PR TITLE
fix(npm): don't prompt for password when --npm-token is given

### DIFF
--- a/src/lib/npm.js
+++ b/src/lib/npm.js
@@ -100,6 +100,7 @@ module.exports = async function(pkg, info) {
       name: 'password',
       message: 'What is your npm password?',
       validate: _.ary(_.bind(validator.isLength, null, _, 1), 1),
+      when: () => !_.has(info.options, 'npm-token'),
     },
     {
       type: 'input',


### PR DESCRIPTION
fix #281