### PR TITLE
fix: 🐛 travis url pointing to semantic-release docs

### DIFF
--- a/src/lib/travis.js
+++ b/src/lib/travis.js
@@ -110,6 +110,6 @@ module.exports = async function(endpoint, pkg, info) {
   await setUpTravis(pkg, info);
 
   console.log(
-    'Please refer to https://github.com/semantic-release/semantic-release/blob/master/docs/03-recipes/travis.md to configure your .travis.yml file.'
+    'Please refer to https://github.com/semantic-release/semantic-release/blob/master/docs/recipes/travis.md to configure your .travis.yml file.'
   );
 };


### PR DESCRIPTION
I just used the cli to setup semantic-release and clicked a broken link, so this PR is just to update the url pointing to travis docs.