### PR TITLE
removing node 8 from travis - it's deprecated and not compatible with xo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: node_js
 node_js:
   - 12
   - 10
-  - 8
 
 # Trigger a push build on master and greenkeeper branches + PRs build on every branches
 # Avoid double build on PRs (See https://github.com/travis-ci/travis-ci/issues/1147)


### PR DESCRIPTION

`error xo@0.29.1: The engine "node" is incompatible with this module. Expected version ">=10.18". Got "8.17.0"`

It causes TravisCI to fail.