### PR TITLE
fix(github): Remove deprecated GitHub Basic Auth flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
-# ⚠️ Currently brokeng for GitHub due to defunkt Basic Auth APIs
-
-See [#351](https://github.com/semantic-release/cli/issues/351)
-
 # semantic-release-cli
 
 [![Travis](https://img.shields.io/travis/semantic-release/cli.svg)](https://travis-ci.org/semantic-release/cli)
@@ -32,7 +28,6 @@ semantic-release-cli setup
     --gh-token=<String>  GitHub auth token
     --npm-token=<String> npm auth token
     --circle-token=<String> CircleCI auth token
-    --gh-username=<String>  GitHub username
     --npm-username=<String>  npm username
 
 	Aliases:
@@ -47,16 +42,13 @@ __semantic-release-cli performs the following steps:__
 	* Your npm username (unless passwords were previously saved to keychain)
 	* Your npm email
 	* Your npm password
-	* Your GitHub username
-	* Your GitHub password (unless passwords were previously saved to keychain)
 	* Which continuous integration system you want to use. (Options: Travis CI / Pro / Enterprise / CircleCI, or Other)
 	* [Travis only] Whether you want to test a single node.js version (e.g. - 8) or multiple node.js versions (e.g. - 4, 6, 8, etc.)
 1. npm Add User
 	* Runs `npm adduser` with the npm information provided to generate a `.npmrc`
 	* Parses the npm token from the `.npmrc` for future use
-1. Create GitHub Personal Token
-	* Logs into GitHub using the username and password provided
-	* Creates (and saves for later use) a [GitHub Personal Access Token](https://github.com/settings/tokens) with the following permissions: *repo, read:org, repo:status, repo_deployment, user:email, write:repo_hook*
+1. Uses user supplied GitHub Personal Access Token (with the following permissions: `repo`, `read:org`, `repo:status`, `repo_deployment`, `user:email`, `write:repo_hook`)
+	* Sets GitHub Personal Access Token in user choosen CI/CD environment variable
 1. Update your `package.json`
 	* Set `version` field to `0.0.0-development` (`semantic-release` will set the version for you automatically)
 	* Add a `semantic-release` script: `"semantic-release": "semantic-release"`
@@ -100,8 +92,8 @@ jobs:
 2. Login to CircleCI to configure the package
 	* Enable builds of your repo
 	* Add `GH_TOKEN` and `NPM_TOKEN` environment variables in the settings
-	
-	
+
+
 ## Github Actions
 
 For Github Actions, `semantic-release-cli` performs the following additional step:
@@ -137,8 +129,6 @@ Note that your CI server will also need to set the environment variable `CI=true
 ## Setting defaults
 
 This package reads your npm username from your global `.npmrc`. In order to autosuggest a username in the future, make sure to set your username there: `npm config set username <username>`.
-
-It also reads your GitHub username from your global `.gitconfig`. In order to autosuggest a username in the future, run `git config --global --add github.username <username>`. If a name isn't defined here, it will default to using your npm username, as it will assume they are identical.
 
 ## Contribute
 

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,6 @@ const knownOptions = {
   'gh-token': String,
   'npm-token': String,
   'circle-token': String,
-  'gh-username': String,
   'npm-username': String,
 };
 
@@ -63,7 +62,6 @@ Options:
   --gh-token=<String>  GitHub auth token
   --npm-token=<String> npm auth token
   --circle-token=<String> CircleCI auth token
-  --gh-username=<String>  GitHub username
   --npm-username=<String>  npm username
 
 Aliases:
@@ -87,7 +85,7 @@ Aliases:
   try {
     await require('./lib/repository')(pkg, info);
     await require('./lib/npm')(pkg, info);
-    await require('./lib/github')(pkg, info);
+    await require('./lib/github')(info);
     await require('./lib/ci')(pkg, info);
   } catch (error) {
     log.error(error);

--- a/src/lib/github.js
+++ b/src/lib/github.js
@@ -1,77 +1,11 @@
 /* eslint require-atomic-updates: off */
 
-const crypto = require('crypto');
+const clipboard = require('clipboardy');
 const _ = require('lodash');
-const base32 = require('base32');
 const inquirer = require('inquirer');
-const npm = require('npm');
-const request = require('request-promise').defaults({resolveWithFullResponse: true});
-const validator = require('validator');
 const log = require('npmlog');
-const gitConfigPath = require('git-config-path')('global');
-const parse = require('parse-git-config');
 
-async function ask2FA() {
-  return (
-    await inquirer.prompt([
-      {
-        type: 'input',
-        name: 'code',
-        message: 'What is your GitHub two-factor authentication code?',
-        validate: validator.isNumeric,
-      },
-    ])
-  ).code;
-}
-
-function randomId() {
-  return base32.encode(crypto.randomBytes(4));
-}
-
-async function createAuthorization(info) {
-  const reponame = info.ghrepo && info.ghrepo.slug[1];
-  const node = (reponame ? `-${reponame}-` : '-') + randomId();
-
-  try {
-    const response = await request({
-      method: 'POST',
-      url: `${info.github.endpoint}/authorizations`,
-      json: true,
-      auth: info.github,
-      headers: {'User-Agent': 'semantic-release', 'X-GitHub-OTP': info.github.code},
-      body: {
-        scopes: [
-          'repo',
-          'read:org',
-          'user:email',
-          'repo_deployment',
-          'repo:status',
-          'write:repo_hook',
-          'write:packages',
-          'read:packages',
-        ],
-        note: `semantic-release${node}`,
-      },
-    });
-    if (response.statusCode === 201) return response.body.token;
-  } catch (error) {
-    if (error.statusCode === 401 && error.response.headers['x-github-otp']) {
-      const [, type] = error.response.headers['x-github-otp'].split('; ');
-
-      if (info.github.retry) log.warn('Invalid two-factor authentication code.');
-      else log.info(`Two-factor authentication code needed via ${type}.`);
-
-      const code = await ask2FA();
-      info.github.code = code;
-      info.github.retry = true;
-      return createAuthorization(info);
-    }
-
-    throw error;
-  }
-}
-
-module.exports = async function (pkg, info) {
+module.exports = async function (info) {
   if (_.has(info.options, 'gh-token')) {
     info.github = {
       endpoint: info.ghepurl || 'https://api.github.com',
@@ -81,32 +15,23 @@ module.exports = async function (pkg, info) {
     return;
   }
 
-  const githubUserFromGitConfig = parse.sync({path: gitConfigPath}).github
-    ? parse.sync({path: gitConfigPath}).github.user
-    : null;
-
   const answers = await inquirer.prompt([
     {
       type: 'input',
-      name: 'username',
-      message: 'What is your GitHub username?',
-      default: info.options['gh-username'] || githubUserFromGitConfig || npm.config.get('username'),
-      validate: _.ary(_.bind(validator.isLength, validator, _, 1), 1),
-    },
-    {
-      type: 'password',
-      name: 'password',
-      message: 'What is your GitHub password?',
-      validate: _.ary(_.bind(validator.isLength, validator, _, 1), 1),
+      name: 'token',
+      message: 'What is your GitHub personal access token?',
+      default: async () => {
+        const clipboardValue = await clipboard.read();
+        return clipboardValue.length === 40 ? clipboardValue : null;
+      },
+      validate: (input) => (input.length === 40 ? true : 'Invalid token length'),
     },
   ]);
 
   info.github = answers;
-  info.github.endpoint = info.ghepurl || 'https://api.github.com';
+  const {token} = info.github;
 
-  const token = await createAuthorization(info);
-
-  if (!token) throw new Error('Could not login to GitHub.');
+  if (!token) throw new Error('User could not supply GitHub Personal Access Token.');
 
   info.github.token = token;
   log.info('Successfully created GitHub token.');

--- a/src/lib/github.js
+++ b/src/lib/github.js
@@ -19,7 +19,7 @@ module.exports = async function (info) {
     {
       type: 'input',
       name: 'token',
-      message: 'What is your GitHub personal access token?',
+      message: 'Provide a GItHub Personal Access Token (create a token at https://github.com/settings/tokens/new?scopes=repo)',
       default: async () => {
         const clipboardValue = await clipboard.read();
         return clipboardValue.length === 40 ? clipboardValue : null;


### PR DESCRIPTION
## What

- 🔧 Removes depracted GitHub Basic Auth flow for obtaining GitHub Personal Access token, moves to request this token from the user via CLI as the app does with things like Circleci OAuth 2 token.