### PR TITLE
fix(github): fixes bug with github token

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -85,7 +85,7 @@ Aliases:
   try {
     await require('./lib/repository')(pkg, info);
     await require('./lib/npm')(pkg, info);
-    await require('./lib/github')(info);
+    await require('./lib/github')(pkg, info);
     await require('./lib/ci')(pkg, info);
   } catch (error) {
     log.error(error);

--- a/src/lib/github.js
+++ b/src/lib/github.js
@@ -5,7 +5,7 @@ const _ = require('lodash');
 const inquirer = require('inquirer');
 const log = require('npmlog');
 
-module.exports = async function (info) {
+module.exports = async function (pkg, info) {
   if (_.has(info.options, 'gh-token')) {
     info.github = {
       endpoint: info.ghepurl || 'https://api.github.com',
@@ -20,7 +20,7 @@ module.exports = async function (info) {
       type: 'input',
       name: 'token',
       message:
-        'Provide a GItHub Personal Access Token (create a token at https://github.com/settings/tokens/new?scopes=repo)',
+        'Provide a GitHub Personal Access Token (create a token at https://github.com/settings/tokens/new?scopes=repo)',
       default: async () => {
         const clipboardValue = await clipboard.read();
         return clipboardValue.length === 40 ? clipboardValue : null;


### PR DESCRIPTION
## What

- Fixes bug with GitHub personal access token input handling
- Fixes typo in casing of GitHub personal access token message

## Sample local run

```sh
❯ npm ls -g --depth=0
/usr/local/lib
├── semantic-release-cli@0.0.0-development -> /Users/REDACTED/Developer/cli
└── semantic-release@17.3.1


~/Developer/REDACTED add-semantic-release
❯ semantic-release-cli setup --npm-token=REDACTED
? What is your npm registry? https://registry.npmjs.org/
? Provide a GitHub Personal Access Token (create a token at https://github.com/settings/tokens/new?scopes=repo) REDACTED
? What CI are you using? Circle CI
? What is your CircleCI API token? REDACTED
? Do you want a `config.yml` file with semantic-release setup? No

~/Developer/glimpse add-semantic-release* 33s
```

@gr2m - Please let me know if this looks ok to fix logging the GitHub token to the package.json via the removal of `pkg` in [PR 352](https://github.com/semantic-release/cli/pull/352/files#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556L90)