### PR TITLE
fix(github): prompt case typo

### DIFF
--- a/src/lib/github.js
+++ b/src/lib/github.js
@@ -20,7 +20,7 @@ module.exports = async function (info) {
       type: 'input',
       name: 'token',
       message:
-        'Provide a GItHub Personal Access Token (create a token at https://github.com/settings/tokens/new?scopes=repo)',
+        'Provide a GitHub Personal Access Token (create a token at https://github.com/settings/tokens/new?scopes=repo)',
       default: async () => {
         const clipboardValue = await clipboard.read();
         return clipboardValue.length === 40 ? clipboardValue : null;


### PR DESCRIPTION
## What

Fixes casing typo w/ GitHub Personal Access Token prompt.

/cc @gr2m 