### PR TITLE
feat: :sparkles: add --no-npm option

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,7 @@ const knownOptions = {
   version: Boolean,
   help: Boolean,
   keychain: Boolean,
+  npm: Boolean,
   'ask-for-passwords': Boolean,
   'gh-token': String,
   'npm-token': String,
@@ -63,6 +64,7 @@ Options:
   --npm-token=<String> npm auth token
   --circle-token=<String> CircleCI auth token
   --npm-username=<String>  npm username
+  --no-npm             Do not setup npm.
 
 Aliases:
   init                 setup`);
@@ -84,7 +86,9 @@ Aliases:
 
   try {
     await require('./lib/repository')(pkg, info);
-    await require('./lib/npm')(pkg, info);
+    if (info.options.npm) {
+      await require('./lib/npm')(pkg, info);
+    }
     await require('./lib/github')(info);
     await require('./lib/ci')(pkg, info);
   } catch (error) {

--- a/src/lib/ci.js
+++ b/src/lib/ci.js
@@ -17,7 +17,7 @@ const cis = {
     const message = `
 ${_.repeat('-', 46)}
 GH_TOKEN=${info.github.token}
-NPM_TOKEN=${info.npm.token}
+${info.options.npm ? "NPM_TOKEN=" + info.npm.token : ""}
 ${_.repeat('-', 46)}
 `;
     console.log(message);


### PR DESCRIPTION
Add the possibility to setup semantic-release using semantic-release-cli w/o npm setup, by passing --no-npm to the cli.

Fixes #318